### PR TITLE
Adds junglebeat wrapper and permits multiple nodes to be added at once

### DIFF
--- a/lib/jungle_beat.rb
+++ b/lib/jungle_beat.rb
@@ -1,0 +1,15 @@
+class JungleBeat
+
+  attr_reader :list
+  def initialize
+    @list = LinkedList.new
+  end
+
+  def append(datas)
+    datas.split.each { |data| @list.append(data) }
+  end
+
+  def count
+    @list.count
+  end
+end

--- a/test/jungle_beat_test.rb
+++ b/test/jungle_beat_test.rb
@@ -1,0 +1,26 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require 'pry'
+require './lib/node'
+require './lib/linked_list'
+require './lib/jungle_beat'
+
+class JungleBeatTest < Minitest::Test
+
+  def test_it_initializes_and_appends
+    jb = JungleBeat.new
+
+    assert_instance_of JungleBeat, jb
+    assert_instance_of LinkedList, jb.list
+    assert_nil jb.list.head
+
+    jb.append("deep doo ditt")
+
+    assert_equal "deep", jb.list.head.data
+    assert_equal "doo", jb.list.head.next_node.data
+
+    jb.append("woo hoo shu")
+
+    assert_equal 6, jb.count
+  end
+end


### PR DESCRIPTION
What does this PR do?
--
This PR completes Iteration 5:
* Adds junglebeat wrapper and permits multiple nodes to be added at one time
* Tests functionality of the jb wrapper