### PR TITLE
Add edge cases

### DIFF
--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -57,12 +57,12 @@ class LinkedList
   end
 
   def pop
-    @head.next_node ? pop_from_linked : pop_single
+    !@head ? pop_empty : !@head.next_node ? pop_single : pop_linked
   end
 
   private
 
-  def pop_from_linked
+  def pop_linked
     node = @head
     node = node.next_node while node.next_node != tail_node
     popped_data = node.next_node.data
@@ -72,8 +72,12 @@ class LinkedList
 
   def pop_single
     popped_data = @head.data
-    @head.data = nil
+    @head = nil
     popped_data
+  end
+
+  def pop_empty
+    nil
   end
 
   def tail_node

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -57,12 +57,24 @@ class LinkedList
   end
 
   def pop
-    node = @head
-    node = node.next_node while node.next_node != tail_node
-    node.next_node = nil
+    @head.next_node ? pop_from_linked : pop_single
   end
 
   private
+
+  def pop_from_linked
+    node = @head
+    node = node.next_node while node.next_node != tail_node
+    popped_data = node.next_node.data
+    node.next_node = nil
+    popped_data
+  end
+
+  def pop_single
+    popped_data = @head.data
+    @head.data = nil
+    popped_data
+  end
 
   def tail_node
     current_node = @head

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -89,7 +89,7 @@ class LinkedList
   def index_node(index)
     index_node = @head
     counter = 0
-    while counter != index
+    while counter != index && counter != count - 1
       counter += 1
       index_node = index_node.next_node
     end

--- a/lib/linked_list.rb
+++ b/lib/linked_list.rb
@@ -43,7 +43,13 @@ class LinkedList
   end
 
   def find(index, quantity)
-    produce_string(index_node(index), quantity)
+    if index > count
+      "The specified node falls outside the list's range between 0 and #{count}"
+    elsif quantity > count - index
+      "Your specified nodes extend beyond the lists range"
+    else
+      produce_string(index_node(index), quantity)
+    end
   end
 
   def includes?(data)

--- a/lib/node.rb
+++ b/lib/node.rb
@@ -1,7 +1,6 @@
 class Node
 
-  attr_reader :data
-  attr_accessor :next_node
+  attr_accessor :data, :next_node
 
   def initialize(data)
     @data = data

--- a/test/linked_list_test.rb
+++ b/test/linked_list_test.rb
@@ -83,4 +83,22 @@ class LinkedListTest < Minitest::Test
     assert_equal "deep", list.pop
     refute list.pop
   end
+
+  def test_if_empty_list_includes_anything
+    list = LinkedList.new
+
+    refute list.head
+
+    list.append("deep")
+    list.append("woo")
+
+    list.pop
+    list.pop
+
+    refute list.head
+
+    list.append("deep")
+
+    assert_equal "deep", list.head.data
+  end
 end

--- a/test/linked_list_test.rb
+++ b/test/linked_list_test.rb
@@ -66,8 +66,8 @@ class LinkedListTest < Minitest::Test
     assert_equal true, list.includes?("blop")
     assert_equal false, list.includes?("dep")
 
-    list.pop
-    list.pop
+    assert_equal "blop", list.pop
+    assert_equal "shu", list.pop
 
     assert_equal "deep woo shi", list.to_string
   end
@@ -79,11 +79,8 @@ class LinkedListTest < Minitest::Test
     list.append("woo")
 
     assert_equal "deep woo", list.to_string
-
-    list.pop
-    list.pop
-    list.pop
-
-    assert_equal "deep woo shi", list.to_string
+    assert_equal "woo", list.pop
+    assert_equal "deep", list.pop
+    refute list.pop
   end
 end

--- a/test/linked_list_test.rb
+++ b/test/linked_list_test.rb
@@ -101,4 +101,15 @@ class LinkedListTest < Minitest::Test
 
     assert_equal "deep", list.head.data
   end
+
+  def test_inserting_elements_after_list_ends_adds_them_to_end
+    list = LinkedList.new
+
+    list.append("deep")
+    list.append("woo")
+
+    list.insert(5, "blop")
+
+    assert_equal "deep woo blop", list.to_string
+  end
 end

--- a/test/linked_list_test.rb
+++ b/test/linked_list_test.rb
@@ -112,4 +112,19 @@ class LinkedListTest < Minitest::Test
 
     assert_equal "deep woo blop", list.to_string
   end
+
+  def test_finding_index_out_of_range
+    list = LinkedList.new
+
+    list.append("deep")
+    list.append("woo")
+
+    expected = "The specified node falls outside the list's range between 0 and 2"
+    actual = list.find(3, 1)
+    assert_equal expected, actual
+
+    expected = "Your specified nodes extend beyond the lists range"
+    actual = list.find(2, 2)
+    assert_equal expected, actual
+  end
 end

--- a/test/linked_list_test.rb
+++ b/test/linked_list_test.rb
@@ -71,4 +71,19 @@ class LinkedListTest < Minitest::Test
 
     assert_equal "deep woo shi", list.to_string
   end
+
+  def test_it_pops_more_nodes_than_exist
+    list = LinkedList.new
+
+    list.append("deep")
+    list.append("woo")
+
+    assert_equal "deep woo", list.to_string
+
+    list.pop
+    list.pop
+    list.pop
+
+    assert_equal "deep woo shi", list.to_string
+  end
 end


### PR DESCRIPTION
What does this PR do?
--
This PR adjusts for edge cases:
* Accounts for pops beyond the available number of nodes
* Makes .pop return the popped data
* Corrects error where a populated, then unpopulated, then repopulated list would be headless
* Adds conditional in .index_node so targets outside of range are added to end of list
* Adds error message when index/quantity arguments in .find exceed the list's limits